### PR TITLE
Fix example for language option

### DIFF
--- a/samples/text_request_chinese.js
+++ b/samples/text_request_chinese.js
@@ -9,11 +9,12 @@
 // var apiai = require("../module/apiai");
 var apiai = require("apiai");
 
-var app = apiai("YOUR_ACCESS_TOKEN");
+var app = apiai("YOUR_ACCESS_TOKEN", {
+    language: 'zh-CN'
+});
 
 var options = {
-    sessionId: '<UNIQE SESSION ID>',
-    language: 'zh-CN'
+    sessionId: '<UNIQE SESSION ID>'
 };
 
 var request = app.textRequest('什么叫发票', options);


### PR DESCRIPTION
This shows the correct way of setting the language option.

See https://github.com/api-ai/apiai-nodejs-client/blob/master/module/apiai.js#L101