### PR TITLE
Fixing a delete contexts crash

### DIFF
--- a/module/delete_contexts_request.js
+++ b/module/delete_contexts_request.js
@@ -44,7 +44,7 @@ DeleteContextsRequest.prototype._headers = function() {
 
 DeleteContextsRequest.prototype._requestOptions = function() {
     var request_options = DeleteContextsRequest.super_.prototype._requestOptions.apply(this, arguments);
-    var contextPath = this.context ? '/' + context : '';
+    var contextPath = this.context ? '/' + this.context : '';
 
     request_options.path = this.endpoint + 'contexts' + contextPath + '?sessionId=' + this.sessionId;
     request_options.method = 'DELETE';


### PR DESCRIPTION
If a context name was passed the DeleteContextsRequest.prototype._requestOptions would crash.